### PR TITLE
requirements.txt添加loguru

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pydantic-core==2.14.6
 pydantic==1.10.13
 rank-bm25
 jieba
+loguru


### PR DESCRIPTION
创建了全新的虚拟环境后，终端运行 `pip install -r requirements.txt` 后，提示缺少了 `loguru` 库。